### PR TITLE
InstagramグラフAPIから返却されるエラー内容の取得項目追加

### DIFF
--- a/pyfacebook/error.py
+++ b/pyfacebook/error.py
@@ -28,6 +28,9 @@ class ErrorMessage(object):
     code = attrib(default=None, type=Optional[str])
     message = attrib(default=None, type=Optional[str])
     error_type = attrib(default="PyFacebookException", type=Optional[str])
+    error_subcode = attrib(default="None", type=Optional[str])
+    error_user_title = attrib(default="None", type=Optional[str])
+    error_user_msg = attrib(default="None", type=Optional[str])
 
 
 class PyFacebookException(Exception):
@@ -42,6 +45,9 @@ class PyFacebookException(Exception):
         self.message = None
         self.type = None
         self.code = None
+        self.error_subcode = None
+        self.error_user_title = None
+        self.error_user_msg = None
         self.fbtrace_id = None
         self.error_type = None
         self.initial(data)
@@ -59,19 +65,25 @@ class PyFacebookException(Exception):
             self.error_type = data.error_type
             self.type = data.error_type
             self.code = data.code
+            self.error_subcode = data.error_subcode
+            self.error_user_title = data.error_user_title
+            self.error_user_msg = data.error_user_msg
             self.data = asdict(data)
         elif isinstance(data, dict):
             self.error_type = "FacebookException"
             self.message = data.get("message")
             self.type = data.get("type")
             self.code = data.get("code")
+            self.error_subcode = data.get("error_subcode")
+            self.error_user_title = data.get("error_user_title")
+            self.error_user_msg = data.get("error_user_msg")
             self.fbtrace_id = data.get("fbtrace_id")
             self.data = {"error": data}
 
     def __repr__(self):
         return (
-            "{0}(code={1},type={2},message={3})".format(
-                self.error_type, self.code, self.type, self.message
+            "{0}(code={1},type={2},message={3},error_subcode={4},error_user_title={5},error_user_msg={6})".format(
+                self.error_type, self.code, self.type, self.message, self.error_subcode, self.error_user_title, self.error_user_msg
             )
         )
 

--- a/pyfacebook/error.py
+++ b/pyfacebook/error.py
@@ -28,9 +28,9 @@ class ErrorMessage(object):
     code = attrib(default=None, type=Optional[str])
     message = attrib(default=None, type=Optional[str])
     error_type = attrib(default="PyFacebookException", type=Optional[str])
-    error_subcode = attrib(default="None", type=Optional[str])
-    error_user_title = attrib(default="None", type=Optional[str])
-    error_user_msg = attrib(default="None", type=Optional[str])
+    error_subcode = attrib(default=None, type=Optional[str])
+    error_user_title = attrib(default=None, type=Optional[str])
+    error_user_msg = attrib(default=None, type=Optional[str])
 
 
 class PyFacebookException(Exception):


### PR DESCRIPTION
InstagramグラフAPIから返却されるエラーの内容で、error_subcode・error_user_title・error_user_msgを受け取れるように修正 エラー内容:https://developers.facebook.com/docs/instagram-api/reference/error-codes